### PR TITLE
Add leaderboard and prevent consecutive colors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,4 @@ python main.py
 - **Başla** seçeneğine tıkladıktan sonra turun ne kadar süreceğini seçebilirsiniz.
 - Oyun sırasında ekranın ortasındaki daire her 4 saniyede bir renk değiştirir. Daire yeşile döndüğünde mümkün olduğunca hızlı bir şekilde **Space** tuşuna basın, ardından daire anında başka bir renge geçer.
 - Sağ üst köşedeki **Kapat** düğmesi oyundan erken çıkmanızı sağlar.
-- Tur bittiğinde ortalama tepki süreniz gösterilir.
+- Oyun sonrasında sonuçlar otomatik olarak kaydedilir ve ana menüdeki **Leaderboard** bölümünden önceki oturumların ortalamalarını ve tüm tepki sürelerini görebilirsiniz.


### PR DESCRIPTION
## Summary
- maintain leaderboard of reaction times in `leaderboard.json`
- show leaderboard from main menu
- avoid consecutive color repetitions when changing circle color
- persist results instead of displaying single average
- document new leaderboard behaviour in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686941ae1670833394fb6792f2159703